### PR TITLE
Dockerfile and start script for LINC

### DIFF
--- a/linc/Dockerfile
+++ b/linc/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:14.04
+RUN apt-get update && apt-get install -y build-essential
+RUN apt-get install -y erlang git libpam0g-dev libpcap0.8-dev
+# Some firewalls block the git:// protocol.  Use HTTPS instead.
+RUN git config --global url."https://".insteadOf git://
+RUN git clone https://github.com/FlowForwarding/LINC-Switch.git
+WORKDIR LINC-Switch
+RUN make compile
+
+# We need a config file to build the release, but the real
+# configuration will be written by config-and-run later.
+RUN cp rel/files/sys.config.orig rel/files/sys.config
+RUN make rel
+
+ADD ./config-and-run ./
+ENTRYPOINT ["./config-and-run"]

--- a/linc/config-and-run
+++ b/linc/config-and-run
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ $# = 0 ]; then
+    echo "Usage: $0 INTERFACE [INTERFACE...]" >&2
+    echo "Configures LINC to use the given interfaces for its ports," >&2
+    echo "and starts it." >&2
+    exit 1
+fi
+
+./scripts/config_gen -s 0 "$@" -c tcp:127.0.0.1:6653 -l 0.0.0.0:6654 -o rel/linc/releases/1.0/sys.config
+exec rel/linc/bin/linc console

--- a/linc/config-and-run
+++ b/linc/config-and-run
@@ -1,11 +1,21 @@
 #!/bin/sh
 
-if [ $# = 0 ]; then
-    echo "Usage: $0 INTERFACE [INTERFACE...]" >&2
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 DATAPATH-ID INTERFACE [INTERFACE...]" >&2
     echo "Configures LINC to use the given interfaces for its ports," >&2
     echo "and starts it." >&2
     exit 1
 fi
 
-./scripts/config_gen -s 0 "$@" -c tcp:127.0.0.1:6653 -l 0.0.0.0:6654 -o rel/linc/releases/1.0/sys.config
+SYSCONFIG=rel/linc/releases/1.0/sys.config
+DPID=$1
+shift
+
+./scripts/config_gen -s 0 "$@" -c tcp:127.0.0.1:6653 -l 0.0.0.0:6654 -o $SYSCONFIG
+# Need to use the linc_us4_oe backend, to be able to specify the datapath id.
+sed -i -e "/{backend,/ {
+  s/linc_us4/linc_us4_oe/
+  s/$/ {datapath_id,\"$DPID\"},/
+}" $SYSCONFIG
+
 exec rel/linc/bin/linc console


### PR DESCRIPTION
The Dockerfile uses the start script in order to be able to start LINC using the interfaces passed on the command line.

This is what I've been using when making Leviathan start a switch.
